### PR TITLE
Remove 'how how' typo in _guides/language/index.md

### DIFF
--- a/src/_guides/language/index.md
+++ b/src/_guides/language/index.md
@@ -15,7 +15,7 @@ These two resources are popular with both beginning Dartisans and experts.
   </div>
   <div class="card">
     <h3><a href="/guides/language/effective-dart">Effective Dart</a></h3>
-    <p>A set of guides that show you how how to write the best Dart code
+    <p>A set of guides that show you how to write the best Dart code
     possible. There are guides on Dart style, documentation, usage,
     and design.</p>
   </div>


### PR DESCRIPTION

![dartsite-pr](https://cloud.githubusercontent.com/assets/3700154/22858904/6fdf9396-f099-11e6-8a3e-049b317db0a4.png)
 Fixes minor 'how how' typo on https://www.dartlang.org/guides/language